### PR TITLE
speed up transcription, fix long audio truncation

### DIFF
--- a/Murmur/Models/AppState.swift
+++ b/Murmur/Models/AppState.swift
@@ -24,6 +24,7 @@ class AppState: ObservableObject {
         didSet { UserDefaults.standard.set(apiKey, forKey: "openaiAPIKey") }
     }
     @Published var lastTranscription: String = ""
+    @Published var recordingElapsedTime: TimeInterval = 0
 
     // v0.1.0: Transcription history
     @Published var history: [TranscriptionEntry] = [] {
@@ -59,6 +60,18 @@ class AppState: ObservableObject {
         }
     }
 
+    // Whisper model variant (local only)
+    @Published var modelVariant: String = "base" {
+        didSet {
+            UserDefaults.standard.set(modelVariant, forKey: "whisperModelVariant")
+            // Force re-init on next transcription so the new model loads
+            localTranscriber.modelVariant = modelVariant
+            localTranscriber.invalidate()
+        }
+    }
+
+    static let availableModels = ["tiny", "tiny.en", "base", "base.en", "small", "small.en"]
+
     // v0.1.0: Audio ducking
     @Published var duckMode: AudioDuckMode = .autoDuck {
         didSet { UserDefaults.standard.set(duckMode.rawValue, forKey: "duckMode") }
@@ -93,7 +106,11 @@ class AppState: ObservableObject {
         }
     }
 
-    lazy var localTranscriber = LocalTranscriber()
+    lazy var localTranscriber: LocalTranscriber = {
+        let t = LocalTranscriber()
+        t.modelVariant = modelVariant
+        return t
+    }()
 
     init() {
         if let saved = UserDefaults.standard.string(forKey: "selectedProvider"),
@@ -104,6 +121,8 @@ class AppState: ObservableObject {
 
         inputDeviceUID = UserDefaults.standard.string(forKey: "inputDeviceUID")
         audioRecorder.selectedDeviceUID = inputDeviceUID
+
+        modelVariant = UserDefaults.standard.string(forKey: "whisperModelVariant") ?? "base"
 
         if let saved = UserDefaults.standard.string(forKey: "duckMode"),
            let mode = AudioDuckMode(rawValue: saved) {
@@ -126,7 +145,17 @@ class AppState: ObservableObject {
         state = .idle
         do {
             audioDucker.duck(mode: duckMode, level: duckLevel)
+            audioRecorder.onElapsedTimeUpdate = { [weak self] elapsed in
+                Task { @MainActor in self?.recordingElapsedTime = elapsed }
+            }
+            audioRecorder.onAutoStop = { [weak self] in
+                Task { @MainActor in
+                    print("[Murmur] Auto-stop: max duration reached")
+                    self?.stopRecordingAndTranscribe()
+                }
+            }
             try audioRecorder.start()
+            recordingElapsedTime = 0
             state = .recording
             print("[Murmur] Recording started")
         } catch {

--- a/Murmur/Services/AudioRecorder.swift
+++ b/Murmur/Services/AudioRecorder.swift
@@ -52,8 +52,10 @@ struct AudioInputDevice: Identifiable, Hashable {
 final class AudioRecorder {
     private var engine: AVAudioEngine?
     private var outputFile: AVAudioFile?
+    private var converter: AVAudioConverter?
     private var tempFileURL: URL?
     private var recordingStartTime: Date?
+    private var durationTimer: Timer?
 
     /// UID of the selected input device. nil = system default.
     var selectedDeviceUID: String?
@@ -61,7 +63,21 @@ final class AudioRecorder {
     /// Saved system default to restore after recording.
     private var savedDefaultDevice: AudioDeviceID?
 
+    /// 16kHz mono — WhisperKit's native format, skips internal resampling.
+    private static let targetSampleRate: Double = 16000
+    private static let targetChannels: AVAudioChannelCount = 1
+
     static let minimumDuration: TimeInterval = 0.3
+    static let maxDuration: TimeInterval = 300 // 5 minutes
+
+    /// Current elapsed recording time, updated every 0.5s.
+    private(set) var elapsedTime: TimeInterval = 0
+
+    /// Called on each timer tick with the elapsed time.
+    var onElapsedTimeUpdate: ((TimeInterval) -> Void)?
+
+    /// Called when recording auto-stops due to max duration.
+    var onAutoStop: (() -> Void)?
 
     var isRunning: Bool { engine?.isRunning ?? false }
 
@@ -88,22 +104,34 @@ final class AudioRecorder {
             throw AudioRecorderError.invalidInputFormat
         }
 
-        // Write in native mic format — WhisperKit resamples to 16kHz internally
+        // Write in 16kHz mono — WhisperKit skips resampling, files are ~12x smaller
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString)
             .appendingPathExtension("wav")
         tempFileURL = url
 
         let writeFormat = AVAudioFormat(commonFormat: .pcmFormatFloat32,
-                                        sampleRate: inputFormat.sampleRate,
-                                        channels: inputFormat.channelCount,
+                                        sampleRate: Self.targetSampleRate,
+                                        channels: Self.targetChannels,
                                         interleaved: false)!
         outputFile = try AVAudioFile(forWriting: url,
                                      settings: writeFormat.settings,
                                      commonFormat: .pcmFormatFloat32,
                                      interleaved: false)
 
+        // Set up converter from mic format to 16kHz mono
+        let needsConversion = inputFormat.sampleRate != Self.targetSampleRate
+                              || inputFormat.channelCount != Self.targetChannels
+        if needsConversion {
+            guard let conv = AVAudioConverter(from: inputFormat, to: writeFormat) else {
+                throw AudioRecorderError.converterCreationFailed
+            }
+            conv.sampleRateConverterQuality = AVAudioQuality.medium.rawValue
+            converter = conv
+        }
+
         var tapCount = 0
+        let conv = converter
         inputNode.installTap(onBus: 0, bufferSize: 4096, format: inputFormat) { [weak self] buffer, _ in
             guard let self, let file = self.outputFile else {
                 if tapCount == 0 { print("[Murmur] TAP: fired but self/file is nil") }
@@ -111,10 +139,24 @@ final class AudioRecorder {
                 return
             }
             do {
-                try file.write(from: buffer)
+                if let conv {
+                    // Downsample to 16kHz mono
+                    let ratio = Self.targetSampleRate / inputFormat.sampleRate
+                    let outputFrames = AVAudioFrameCount(Double(buffer.frameLength) * ratio)
+                    guard let convertedBuffer = AVAudioPCMBuffer(pcmFormat: writeFormat, frameCapacity: outputFrames) else { return }
+                    var error: NSError?
+                    conv.convert(to: convertedBuffer, error: &error) { _, outStatus in
+                        outStatus.pointee = .haveData
+                        return buffer
+                    }
+                    if let error { print("[Murmur] TAP convert error: \(error)"); return }
+                    try file.write(from: convertedBuffer)
+                } else {
+                    try file.write(from: buffer)
+                }
                 tapCount += 1
                 if tapCount == 1 {
-                    print("[Murmur] TAP: first buffer written, frames=\(buffer.frameLength)")
+                    print("[Murmur] TAP: first buffer written, frames=\(buffer.frameLength), converting=\(conv != nil)")
                 }
             } catch {
                 print("[Murmur] TAP write error: \(error)")
@@ -125,6 +167,19 @@ final class AudioRecorder {
         try newEngine.start()
         engine = newEngine
         recordingStartTime = Date()
+        elapsedTime = 0
+
+        // Update elapsed time every 0.5s, auto-stop at max duration
+        let timer = Timer(timeInterval: 0.5, repeats: true) { [weak self] _ in
+            guard let self, let start = self.recordingStartTime else { return }
+            self.elapsedTime = Date().timeIntervalSince(start)
+            self.onElapsedTimeUpdate?(self.elapsedTime)
+            if self.elapsedTime >= Self.maxDuration {
+                self.onAutoStop?()
+            }
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        durationTimer = timer
     }
 
     func stop() -> URL? {
@@ -141,9 +196,6 @@ final class AudioRecorder {
 
         guard let url = tempFileURL else { return nil }
 
-        // Small delay to ensure AVAudioFile is fully flushed after engine stop
-        Thread.sleep(forTimeInterval: 0.05)
-
         let minFileSize: UInt64 = 5000
         guard let attrs = try? FileManager.default.attributesOfItem(atPath: url.path),
               let fileSize = attrs[.size] as? UInt64,
@@ -157,12 +209,15 @@ final class AudioRecorder {
     }
 
     private func tearDown() {
+        durationTimer?.invalidate()
+        durationTimer = nil
         if let engine {
             engine.inputNode.removeTap(onBus: 0)
             engine.stop()
         }
         engine = nil
         outputFile = nil
+        converter = nil
         recordingStartTime = nil
         // Restore previous system default input if we changed it
         if let saved = savedDefaultDevice {

--- a/Murmur/Services/CloudTranscriber.swift
+++ b/Murmur/Services/CloudTranscriber.swift
@@ -1,3 +1,4 @@
+import AVFoundation
 import Foundation
 
 final class CloudTranscriber: TranscriptionProvider {
@@ -8,14 +9,16 @@ final class CloudTranscriber: TranscriptionProvider {
     }
 
     func transcribe(fileURL: URL, prompt: String) async throws -> String {
-        let audioData = try Data(contentsOf: fileURL)
+        // Compress WAV to m4a (AAC) for faster upload — typically 10-20x smaller
+        let (uploadData, filename, contentType) = try compressToM4A(from: fileURL)
+
         let boundary = UUID().uuidString
 
         var request = URLRequest(url: URL(string: "https://api.openai.com/v1/audio/transcriptions")!)
         request.httpMethod = "POST"
         request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
         request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
-        request.httpBody = buildMultipartBody(audioData: audioData, prompt: prompt, boundary: boundary)
+        request.httpBody = buildMultipartBody(audioData: uploadData, filename: filename, contentType: contentType, prompt: prompt, boundary: boundary)
 
         let (data, response) = try await URLSession.shared.data(for: request)
 
@@ -33,12 +36,64 @@ final class CloudTranscriber: TranscriptionProvider {
         return text.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
-    private func buildMultipartBody(audioData: Data, prompt: String, boundary: String) -> Data {
+    /// Compress WAV to m4a (AAC). Falls back to raw WAV on failure.
+    private func compressToM4A(from wavURL: URL) throws -> (Data, String, String) {
+        let outputURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension("m4a")
+        defer { try? FileManager.default.removeItem(at: outputURL) }
+
+        do {
+            let inputFile = try AVAudioFile(forReading: wavURL)
+            let inputFormat = inputFile.processingFormat
+            guard let outputFormat = AVAudioFormat(
+                standardFormatWithSampleRate: inputFormat.sampleRate,
+                channels: inputFormat.channelCount
+            ) else {
+                throw CloudTranscriberError.compressionFailed
+            }
+
+            let outputSettings: [String: Any] = [
+                AVFormatIDKey: kAudioFormatMPEG4AAC,
+                AVSampleRateKey: inputFormat.sampleRate,
+                AVNumberOfChannelsKey: inputFormat.channelCount,
+                AVEncoderBitRateKey: 64000,
+            ]
+
+            let outputFile = try AVAudioFile(
+                forWriting: outputURL,
+                settings: outputSettings,
+                commonFormat: outputFormat.commonFormat,
+                interleaved: outputFormat.isInterleaved
+            )
+
+            let bufferSize: AVAudioFrameCount = 4096
+            guard let buffer = AVAudioPCMBuffer(pcmFormat: inputFormat, frameCapacity: bufferSize) else {
+                throw CloudTranscriberError.compressionFailed
+            }
+
+            while inputFile.framePosition < inputFile.length {
+                try inputFile.read(into: buffer)
+                try outputFile.write(from: buffer)
+            }
+
+            let compressedData = try Data(contentsOf: outputURL)
+            let originalSize = (try? FileManager.default.attributesOfItem(atPath: wavURL.path)[.size] as? UInt64) ?? 0
+            print("[Murmur] Cloud: compressed \(originalSize) bytes WAV → \(compressedData.count) bytes m4a")
+            return (compressedData, "audio.m4a", "audio/mp4")
+        } catch {
+            print("[Murmur] Cloud: m4a compression failed (\(error)), using raw WAV")
+            let wavData = try Data(contentsOf: wavURL)
+            return (wavData, "audio.wav", "audio/wav")
+        }
+    }
+
+    private func buildMultipartBody(audioData: Data, filename: String, contentType: String, prompt: String, boundary: String) -> Data {
         var body = Data()
 
         body.appendString("--\(boundary)\r\n")
-        body.appendString("Content-Disposition: form-data; name=\"file\"; filename=\"audio.wav\"\r\n")
-        body.appendString("Content-Type: audio/wav\r\n\r\n")
+        body.appendString("Content-Disposition: form-data; name=\"file\"; filename=\"\(filename)\"\r\n")
+        body.appendString("Content-Type: \(contentType)\r\n\r\n")
         body.append(audioData)
         body.appendString("\r\n")
 
@@ -63,6 +118,7 @@ final class CloudTranscriber: TranscriptionProvider {
     enum CloudTranscriberError: Error, LocalizedError {
         case invalidResponse
         case apiError(statusCode: Int, message: String)
+        case compressionFailed
 
         var errorDescription: String? {
             switch self {
@@ -70,6 +126,8 @@ final class CloudTranscriber: TranscriptionProvider {
                 return "Invalid response from OpenAI API"
             case .apiError(let statusCode, let message):
                 return "OpenAI API error (\(statusCode)): \(message)"
+            case .compressionFailed:
+                return "Failed to compress audio for upload"
             }
         }
     }

--- a/Murmur/Services/LocalTranscriber.swift
+++ b/Murmur/Services/LocalTranscriber.swift
@@ -4,23 +4,31 @@ import WhisperKit
 final class LocalTranscriber: TranscriptionProvider {
     private var whisperKit: WhisperKit?
 
+    /// Whisper model variant to use (e.g. "tiny.en", "base", "small.en").
+    var modelVariant: String?
+
     /// Called on main thread with (fractionCompleted 0-1, status string).
     var onProgress: ((Double, String) -> Void)?
 
     var isReady: Bool { whisperKit != nil }
 
+    /// Force re-initialization on next transcription (e.g. after model change).
+    func invalidate() {
+        whisperKit = nil
+    }
+
     func transcribe(fileURL: URL, prompt: String) async throws -> String {
         let kit = try await resolveWhisperKit()
 
         do {
-            let results: [TranscriptionResult]
+            var options = DecodingOptions(
+                temperatureFallbackCount: 2,
+                chunkingStrategy: .vad
+            )
             if !prompt.isEmpty, let tokenizer = kit.tokenizer {
-                let tokens = tokenizer.encode(text: prompt)
-                let options = DecodingOptions(promptTokens: tokens)
-                results = try await kit.transcribe(audioPath: fileURL.path, decodeOptions: options)
-            } else {
-                results = try await kit.transcribe(audioPath: fileURL.path)
+                options.promptTokens = tokenizer.encode(text: prompt)
             }
+            let results = try await kit.transcribe(audioPath: fileURL.path, decodeOptions: options)
             return results.compactMap(\.text).joined(separator: " ").trimmingCharacters(in: .whitespaces)
         } catch {
             print("[Murmur] WhisperKit error, will reinit next call: \(error)")
@@ -44,8 +52,9 @@ final class LocalTranscriber: TranscriptionProvider {
 
         let progressCb = self.onProgress
         let config = WhisperKitConfig(
+            model: modelVariant,
             verbose: false,
-            prewarm: true,
+            prewarm: false,
             load: true,
             download: true
         )

--- a/Murmur/Views/MenuBarView.swift
+++ b/Murmur/Views/MenuBarView.swift
@@ -75,6 +75,13 @@ struct MenuBarView: View {
                 Text(type.rawValue).tag(type)
             }
         }
+        if appState.selectedProvider == .local {
+            Picker("Model", selection: $appState.modelVariant) {
+                ForEach(AppState.availableModels, id: \.self) { model in
+                    Text(model).tag(model)
+                }
+            }
+        }
         if appState.selectedProvider == .cloud {
             SecureField("OpenAI API Key", text: $appState.apiKey)
                 .textFieldStyle(.roundedBorder)
@@ -239,7 +246,7 @@ struct MenuBarView: View {
         HotkeyConfig.clearSaved()
         PillWindowController.clearPosition()
         Profile.clearSaved()
-        for key in ["selectedProvider", "openaiAPIKey", "duckMode", "duckLevel", "transcriptionHistory", "lastUpdateCheck"] {
+        for key in ["selectedProvider", "openaiAPIKey", "duckMode", "duckLevel", "transcriptionHistory", "lastUpdateCheck", "whisperModelVariant"] {
             UserDefaults.standard.removeObject(forKey: key)
         }
         let cacheDir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first

--- a/Murmur/Views/PillOverlay.swift
+++ b/Murmur/Views/PillOverlay.swift
@@ -37,6 +37,18 @@ struct PillOverlay: View {
                                 .progressViewStyle(.circular)
                                 .scaleEffect(0.8)
                                 .colorInvert()
+                        } else if appState.state == .recording {
+                            VStack(spacing: 2) {
+                                pillIcon
+                                    .renderingMode(.template)
+                                    .resizable()
+                                    .scaledToFit()
+                                    .frame(height: 16)
+                                    .foregroundStyle(.white)
+                                Text(formattedElapsed)
+                                    .font(.system(size: 11, weight: .medium, design: .monospaced))
+                                    .foregroundStyle(.white.opacity(0.9))
+                            }
                         } else {
                             pillIcon
                                 .renderingMode(.template)
@@ -149,13 +161,25 @@ struct PillOverlay: View {
         return Image(systemName: "mic.fill")
     }
 
+    private var formattedElapsed: String {
+        let t = Int(appState.recordingElapsedTime)
+        return String(format: "%d:%02d", t / 60, t % 60)
+    }
+
+    private var durationFraction: Double {
+        appState.recordingElapsedTime / AudioRecorder.maxDuration
+    }
+
     private var backgroundColor: Color {
         switch appState.state {
-        case .idle: .gray.opacity(0.8)
-        case .recording: .red
-        case .transcribing: .orange
-        case .done: .green
-        case .error: .red.opacity(0.7)
+        case .idle: return .gray.opacity(0.8)
+        case .recording:
+            if durationFraction >= 0.95 { return .red }
+            if durationFraction >= 0.80 { return .orange }
+            return .red
+        case .transcribing: return .orange
+        case .done: return .green
+        case .error: return .red.opacity(0.7)
         }
     }
 


### PR DESCRIPTION
- record 16kHz mono via AVAudioConverter (12x smaller files, skip WhisperKit resampling)
- enable VAD chunking + reduce temperature fallbacks for reliable long audio
- add model selection (tiny/base/small variants) in menu
- compress WAV→m4a before cloud upload
- remove blocking Thread.sleep after recording
- add duration timer w/ 5min auto-stop + elapsed display in pill
- pill color warns at 80%/95% of max duration

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
